### PR TITLE
Fix typo in Request::REPLAY_REQUEST

### DIFF
--- a/src/Yubikey/Response.php
+++ b/src/Yubikey/Response.php
@@ -87,7 +87,7 @@ class Response
      */
     const SUCCESS = 'OK';
     const REPLAY_OTP = 'REPLAYED_OTP';
-    const REPLAY_REQUEST = 'REPLAY_REQUEST';
+    const REPLAY_REQUEST = 'REPLAYED_REQUEST';
     const MISSING_PARAMETER = 'MISSING_PARAMETER';
     const NO_CLIENT = 'NO_SUCH_CLIENT';
     const BAD_OTP = 'BAD_OTP';


### PR DESCRIPTION
Request::REPLAY_REQUEST was incorrectly set to "REPLAY_REQUEST" rather than "REPLAYED_REQUEST" (see https://developers.yubico.com/yubikey-val/Validation_Protocol_V2.0.html)